### PR TITLE
Add GitHub Bug Report and Feature Request Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,45 @@
+name: Bug Report
+description: Report a Bug or Problem
+title: "[Bug]: "
+labels: [ "bug" ]
+body:
+  - type: markdown
+    attributes:    
+      value: |
+        Thank you for taking the time to report your issue!
+        * Please try to report a *single* issue per report to help make them easier to track.
+        * Please double check that someone else hasn't already reported the same issue.
+  - type: input
+    id: gameversion
+    validations:
+      required: true
+    attributes:
+      label: Game Version
+      description: What is your **version number**?
+      placeholder: "Example: v0.8.7"
+  - type: input
+    id: platform
+    validations:
+      required: true
+    attributes:
+      label: Platform
+      description: What is your **Operating System**?
+      placeholder: "Example: Windows 11 64-bit, Ubuntu 12.10, MacOS 13.0, etc"
+  - type: textarea
+    id: problem
+    validations:
+      required: true
+    attributes:
+      label: What happened?
+      description: Describe the thing that lead you here. Was something not working as expected? What were you doing when it happened?
+      placeholder: |
+        Example:
+        I was walking around in the forest at night, and grave yard fog covered my screen when day came. I was in a grave yard before it turned to night last, and was in a battle when day came.
+  - type: textarea
+    id: expectation
+    attributes:
+      label: "What should've happened? (Optional)"
+      description: "Give a brief description about what you believe should've happened in this situation."
+      placeholder: |
+        Example:
+        The grave yard fog is only supposed to appear in the grave yard biome, does not appear in the forest normally.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,19 @@
+name: Feature Request
+description: Request a Feature to be added to the game
+title: "[Feature Request]: "
+labels: [ "enhancement" ]
+body:
+  - type: markdown
+    attributes:    
+      value: |
+        Thank you for taking the time to Request a feature!
+        * Please try to request a *single* feature per issue to help make them easier to track.
+        * Please double check that someone else hasn't already requested the same thing.
+        * Please double check the [Future Plans](https://github.com/SheerSt/pokemon-wilds/wiki/Future-Plans-(WIP)) to ensure your idea isn't already planned.
+  - type: textarea
+    id: feature
+    validations:
+      required: true
+    attributes:
+      label: What would you like to request?
+      description: "Give a description of the feature you'd like to see in the game and why."


### PR DESCRIPTION
> Having a template can encourage users to provide helpful information and provide better organization to the structure of issue reports
>
> It can also help encourage users to include one issue per report

I've done my best to create flexible issue templates to help make tracking issues a little easier after noticing a few issue reports such as:

#109
Which looks like it intends to be a bulk list of issues built later,  but for now contains a single **Feature Request** for **Custom Control Bindings**

#250
where the user is confused about whether or not their Feature Request counts as an issue and has made a long title as a result

#252
which appears to be a comment about #242 rather than its own issue

#263
Which is a possible duplicate of #223

#271
in which several unrelated issues are grouped together in a bulk list.

#305
which appears to be a #242 Duplicate

#308 
in which a request for an Android port is made on a very vague "performance issue" report